### PR TITLE
56 initial transaction state

### DIFF
--- a/common/src/main/java/com/commercetools/payment/methods/CreatePaymentTransactionMethodBase.java
+++ b/common/src/main/java/com/commercetools/payment/methods/CreatePaymentTransactionMethodBase.java
@@ -4,10 +4,7 @@ import com.commercetools.payment.domain.PaymentTransactionCreationResultBuilder;
 import com.commercetools.payment.model.CreatePaymentTransactionData;
 import com.commercetools.payment.model.PaymentTransactionCreationResult;
 import io.sphere.sdk.commands.UpdateAction;
-import io.sphere.sdk.payments.Payment;
-import io.sphere.sdk.payments.TransactionDraft;
-import io.sphere.sdk.payments.TransactionDraftBuilder;
-import io.sphere.sdk.payments.TransactionType;
+import io.sphere.sdk.payments.*;
 import io.sphere.sdk.payments.commands.PaymentUpdateCommand;
 import io.sphere.sdk.payments.commands.updateactions.AddTransaction;
 import io.sphere.sdk.types.Custom;
@@ -55,7 +52,8 @@ public abstract class CreatePaymentTransactionMethodBase implements CreatePaymen
     protected TransactionDraftBuilder createTransactionDraftBuilder(CreatePaymentTransactionData data, TransactionType defaultType) {
         return TransactionDraftBuilder.of(
                 data.getTransactionType().orElse(defaultType),
-                data.getPayment().getAmountPlanned());
+                data.getPayment().getAmountPlanned())
+                .state(TransactionState.INITIAL);
     }
 
     @Nullable
@@ -67,7 +65,6 @@ public abstract class CreatePaymentTransactionMethodBase implements CreatePaymen
     }
 
     /**
-     *
      * @param paymentWithoutRedirect updated payment reference
      * @return {@link PaymentTransactionCreationResult} with
      * {@link com.commercetools.payment.actions.OperationResult#SUCCESS}

--- a/common/src/main/java/com/commercetools/payment/utils/impl/PaymentConnectorHelperImpl.java
+++ b/common/src/main/java/com/commercetools/payment/utils/impl/PaymentConnectorHelperImpl.java
@@ -20,7 +20,6 @@ public class PaymentConnectorHelperImpl implements PaymentConnectorHelper {
     public CompletionStage<HttpRequestResult> sendHttpGetRequest(String url) {
         HttpRequest request = HttpRequest.of(HttpMethod.GET, url);
 
-        // TODO: must be injected, instead of initialization!!!
         HttpClient client = SphereClientFactory.of().createHttpClient();
 
         return client.execute(request)

--- a/common/src/test/java/com/commercetools/payment/methods/CreatePaymentTransactionMethodBaseTest.java
+++ b/common/src/test/java/com/commercetools/payment/methods/CreatePaymentTransactionMethodBaseTest.java
@@ -1,0 +1,122 @@
+package com.commercetools.payment.methods;
+
+import com.commercetools.payment.model.CreatePaymentTransactionData;
+import com.commercetools.payment.model.impl.CreatePaymentTransactionDataImpl;
+import io.sphere.sdk.client.SphereClient;
+import io.sphere.sdk.payments.Payment;
+import io.sphere.sdk.payments.TransactionDraft;
+import io.sphere.sdk.payments.commands.PaymentUpdateCommand;
+import io.sphere.sdk.payments.commands.updateactions.AddTransaction;
+import org.javamoney.moneta.Money;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import javax.money.MonetaryAmount;
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.sphere.sdk.payments.TransactionState.INITIAL;
+import static io.sphere.sdk.payments.TransactionType.AUTHORIZATION;
+import static io.sphere.sdk.payments.TransactionType.CHARGE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CreatePaymentTransactionMethodBaseTest {
+
+    @Mock
+    private CreatePaymentTransactionMethodBase createPaymentTransactionMethod;
+
+    @Mock
+    private SphereClient sphereClient;
+
+    @Mock
+    private Payment payment;
+
+    private CreatePaymentTransactionData transactionData;
+
+    private MonetaryAmount amount42;
+
+    @Before
+    public void setUp() {
+        Map<String, String> configMap = new HashMap<>();
+        configMap.put("key1", "value1");
+        configMap.put("key2", "value2");
+
+        amount42 = Money.of(42.42, "EUR");
+
+        when(payment.getAmountPlanned()).thenReturn(amount42);
+
+        transactionData = new CreatePaymentTransactionDataImpl(sphereClient, "mock-ref", configMap);
+        transactionData.setPayment(payment);
+
+        doCallRealMethod().when(createPaymentTransactionMethod).createPaymentTransaction(any(), any());
+        doCallRealMethod().when(createPaymentTransactionMethod).createTransactionDraftBuilder(any(), any());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void createPaymentTransaction_sendsPaymentUpdateCommandWithInitialTransactionState() {
+        createPaymentTransactionMethod.createPaymentTransaction(transactionData, AUTHORIZATION);
+
+        ArgumentCaptor<PaymentUpdateCommand> updateCommand = ArgumentCaptor.forClass(PaymentUpdateCommand.class);
+        verify(sphereClient, times(1)).execute(updateCommand.capture());
+
+        assertThat(updateCommand.getValue().getUpdateActions())
+                .filteredOn(action -> action instanceof AddTransaction)
+                .extracting(action -> ((AddTransaction) action).getTransaction().getState())
+                .containsExactly(INITIAL);
+    }
+
+    @Test
+    public void createTransactionDraftBuilder_simpleCase() {
+        TransactionDraft transactionDraft = createPaymentTransactionMethod.createTransactionDraftBuilder(transactionData, AUTHORIZATION).build();
+        assertThat(transactionDraft).isNotNull();
+        assertThat(transactionDraft.getTimestamp()).isNull();
+        assertThat(transactionDraft.getInteractionId()).isNull();
+        assertThat(transactionDraft.getAmount()).isEqualByComparingTo(Money.of(42.42, "EUR"));
+        assertThat(transactionDraft.getType()).isEqualByComparingTo(AUTHORIZATION);
+        assertThat(transactionDraft.getState()).isEqualByComparingTo(INITIAL);
+
+        transactionDraft = createPaymentTransactionMethod.createTransactionDraftBuilder(transactionData, CHARGE).build();
+        assertThat(transactionDraft).isNotNull();
+        assertThat(transactionDraft.getTimestamp()).isNull();
+        assertThat(transactionDraft.getInteractionId()).isNull();
+        assertThat(transactionDraft.getAmount()).isEqualByComparingTo(Money.of(42.42, "EUR"));
+        assertThat(transactionDraft.getType()).isEqualByComparingTo(CHARGE);
+        assertThat(transactionDraft.getState()).isEqualByComparingTo(INITIAL);
+    }
+
+    @Test
+    public void whenTransactionTypeIsSetInData_createTransactionDraftBuilder_usesValueFromData() {
+        transactionData.setTransactionType(CHARGE);
+        TransactionDraft transactionDraft = createPaymentTransactionMethod.createTransactionDraftBuilder(transactionData, AUTHORIZATION).build();
+        assertThat(transactionDraft).isNotNull();
+        assertThat(transactionDraft.getType()).isEqualByComparingTo(CHARGE);
+        assertThat(transactionDraft.getState()).isEqualByComparingTo(INITIAL);
+
+        transactionData.setTransactionType(AUTHORIZATION);
+        transactionDraft = createPaymentTransactionMethod.createTransactionDraftBuilder(transactionData, CHARGE).build();
+        assertThat(transactionDraft).isNotNull();
+        assertThat(transactionDraft.getType()).isEqualByComparingTo(AUTHORIZATION);
+        assertThat(transactionDraft.getState()).isEqualByComparingTo(INITIAL);
+    }
+
+    @Test
+    public void whenTransactionTypeSkippedInData_createTransactionDraftBuilder_usesValueFromDefault() {
+        TransactionDraft transactionDraft = createPaymentTransactionMethod.createTransactionDraftBuilder(transactionData, AUTHORIZATION).build();
+        assertThat(transactionDraft).isNotNull();
+        assertThat(transactionDraft.getType()).isEqualByComparingTo(AUTHORIZATION);
+        assertThat(transactionDraft.getState()).isEqualByComparingTo(INITIAL);
+
+        transactionDraft = createPaymentTransactionMethod.createTransactionDraftBuilder(transactionData, CHARGE).build();
+        assertThat(transactionDraft).isNotNull();
+        assertThat(transactionDraft.getType()).isEqualByComparingTo(CHARGE);
+        assertThat(transactionDraft.getState()).isEqualByComparingTo(INITIAL);
+    }
+}

--- a/common/src/test/java/com/commercetools/payment/methods/CreatePaymentTransactionMethodBaseTest.java
+++ b/common/src/test/java/com/commercetools/payment/methods/CreatePaymentTransactionMethodBaseTest.java
@@ -93,21 +93,6 @@ public class CreatePaymentTransactionMethodBaseTest {
     }
 
     @Test
-    public void whenTransactionTypeIsSetInData_createTransactionDraftBuilder_usesValueFromData() {
-        transactionData.setTransactionType(CHARGE);
-        TransactionDraft transactionDraft = createPaymentTransactionMethod.createTransactionDraftBuilder(transactionData, AUTHORIZATION).build();
-        assertThat(transactionDraft).isNotNull();
-        assertThat(transactionDraft.getType()).isEqualByComparingTo(CHARGE);
-        assertThat(transactionDraft.getState()).isEqualByComparingTo(INITIAL);
-
-        transactionData.setTransactionType(AUTHORIZATION);
-        transactionDraft = createPaymentTransactionMethod.createTransactionDraftBuilder(transactionData, CHARGE).build();
-        assertThat(transactionDraft).isNotNull();
-        assertThat(transactionDraft.getType()).isEqualByComparingTo(AUTHORIZATION);
-        assertThat(transactionDraft.getState()).isEqualByComparingTo(INITIAL);
-    }
-
-    @Test
     public void whenTransactionTypeSkippedInData_createTransactionDraftBuilder_usesValueFromDefault() {
         TransactionDraft transactionDraft = createPaymentTransactionMethod.createTransactionDraftBuilder(transactionData, AUTHORIZATION).build();
         assertThat(transactionDraft).isNotNull();
@@ -117,6 +102,26 @@ public class CreatePaymentTransactionMethodBaseTest {
         transactionDraft = createPaymentTransactionMethod.createTransactionDraftBuilder(transactionData, CHARGE).build();
         assertThat(transactionDraft).isNotNull();
         assertThat(transactionDraft.getType()).isEqualByComparingTo(CHARGE);
+        assertThat(transactionDraft.getState()).isEqualByComparingTo(INITIAL);
+    }
+
+    /**
+     * Same as {@link #whenTransactionTypeSkippedInData_createTransactionDraftBuilder_usesValueFromDefault()},
+     * but sets explicitly transaction type <code>transactionData.setTransactionType(CHARGE);</code>
+     */
+    @Test
+    public void whenTransactionTypeIsSetInData_createTransactionDraftBuilder_usesValueFromData() {
+        transactionData.setTransactionType(CHARGE);
+
+        TransactionDraft transactionDraft = createPaymentTransactionMethod.createTransactionDraftBuilder(transactionData, AUTHORIZATION).build();
+        assertThat(transactionDraft).isNotNull();
+        assertThat(transactionDraft.getType()).isEqualByComparingTo(CHARGE);
+        assertThat(transactionDraft.getState()).isEqualByComparingTo(INITIAL);
+
+        transactionData.setTransactionType(AUTHORIZATION);
+        transactionDraft = createPaymentTransactionMethod.createTransactionDraftBuilder(transactionData, CHARGE).build();
+        assertThat(transactionDraft).isNotNull();
+        assertThat(transactionDraft.getType()).isEqualByComparingTo(AUTHORIZATION);
         assertThat(transactionDraft.getState()).isEqualByComparingTo(INITIAL);
     }
 }

--- a/payone-adapter/src/test/java/com/commercetools/payment/payone/methods/transaction/BasePayoneCreatePaymentTransactionMethodProviderTest.java
+++ b/payone-adapter/src/test/java/com/commercetools/payment/payone/methods/transaction/BasePayoneCreatePaymentTransactionMethodProviderTest.java
@@ -2,13 +2,30 @@ package com.commercetools.payment.payone.methods.transaction;
 
 import com.commercetools.payment.actions.OperationResult;
 import com.commercetools.payment.actions.ShopAction;
+import com.commercetools.payment.domain.CreatePaymentTransactionDataBuilder;
 import com.commercetools.payment.model.PaymentTransactionCreationResult;
+import com.commercetools.payment.model.impl.CreatePaymentTransactionDataImpl;
+import io.sphere.sdk.client.SphereClient;
+import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.payments.Payment;
+import io.sphere.sdk.payments.PaymentMethodInfo;
+import io.sphere.sdk.payments.TransactionType;
+import io.sphere.sdk.payments.commands.PaymentUpdateCommand;
+import io.sphere.sdk.payments.commands.updateactions.AddTransaction;
 import io.sphere.sdk.types.CustomFields;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 
+import javax.annotation.Nullable;
+import javax.money.MonetaryAmount;
+import java.util.List;
+
+import static io.sphere.sdk.payments.TransactionState.INITIAL;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 /**
  * Inherited classes must be run with {@code @RunWith(MockitoJUnitRunner.class)}
@@ -23,12 +40,59 @@ public class BasePayoneCreatePaymentTransactionMethodProviderTest {
     @Mock
     protected CustomFields customFields;
 
+    @Mock
+    protected SphereClient sphereClient;
+
 
     /**
-     * Stub {@link #customFields} into {@link Payment#getCustom()}.
+     * Stub {@link #customFields} to the {@link #payment}.
      */
-    protected void applyStubbing() {
+    protected void applyCustomFieldStubbing() {
         when(payment.getCustom()).thenReturn(customFields);
+    }
+
+    /**
+     * Stub {@code paymentInterface} and {@code amount} to the {@link #payment}.
+     */
+    protected void applyPaymentStubbing(@Nullable PaymentMethodInfo paymentInterface, @Nullable MonetaryAmount amount) {
+        when(payment.getAmountPlanned()).thenReturn(amount);
+        when(payment.getPaymentMethodInfo()).thenReturn(paymentInterface);
+    }
+
+    /**
+     * Without real Sphere and Payone service calls, verify that these services would be called
+     * with expected add transaction update actions.
+     */
+    protected void whenCreateTransactionFunctionApplied_addTransactionWithExpectedValuesIsCalled(TransactionType transactionType,
+                                                                                                 MonetaryAmount expectedAmount) {
+        // mock responses
+        CreatePaymentTransactionDataImpl cptd = CreatePaymentTransactionDataBuilder.of(sphereClient, "test-payment-ref-id")
+                .setTransactionType(transactionType)
+                .build();
+        cptd.setPayment(payment);
+
+        Payment paymentToReturn = mock(Payment.class);
+        when(sphereClient.execute(any(PaymentUpdateCommand.class))).thenReturn(completedFuture(paymentToReturn));
+
+        // make the actual call
+        transactionMethod.create().apply(cptd).toCompletableFuture().join();
+
+        // verify arguments passed to the call
+        ArgumentCaptor<PaymentUpdateCommand> paymentUpdateCommandCaptor = ArgumentCaptor.forClass(PaymentUpdateCommand.class);
+        verify(sphereClient).execute(paymentUpdateCommandCaptor.capture());
+        List<? extends UpdateAction<Payment>> addTransactionActions = paymentUpdateCommandCaptor.getValue().getUpdateActions().stream()
+                .filter(a -> a instanceof AddTransaction)
+                .collect(toList());
+
+        // only 1 AddTransaction is expected with following type/state/amount:
+        assertThat(addTransactionActions.size()).isEqualTo(1);
+        AddTransaction tr = (AddTransaction) addTransactionActions.get(0);
+        assertThat(tr.getTransaction().getType()).isEqualByComparingTo(transactionType);
+        assertThat(tr.getTransaction().getAmount()).isEqualByComparingTo(expectedAmount);
+
+        // since http://dev.commercetools.com/release-notes.html#release-notes---commercetools-platform---version-release-29-september-2017
+        // all transactions should be created with explicit initial state
+        assertThat(tr.getTransaction().getState()).isEqualByComparingTo(INITIAL);
     }
 
     public void handleSuccessfulServiceCall_default() throws Exception {

--- a/payone-adapter/src/test/java/com/commercetools/payment/payone/methods/transaction/PayoneBankTransferCreateTransactionMethodProviderTest.java
+++ b/payone-adapter/src/test/java/com/commercetools/payment/payone/methods/transaction/PayoneBankTransferCreateTransactionMethodProviderTest.java
@@ -1,9 +1,15 @@
 package com.commercetools.payment.payone.methods.transaction;
 
+import io.sphere.sdk.payments.PaymentMethodInfo;
+import io.sphere.sdk.payments.PaymentMethodInfoBuilder;
+import org.javamoney.moneta.Money;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
+
+import static com.commercetools.payment.payone.config.PayonePaymentMethodKeys.BANK_TRANSFER_ADVANCE;
+import static io.sphere.sdk.payments.TransactionType.AUTHORIZATION;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PayoneBankTransferCreateTransactionMethodProviderTest
@@ -11,8 +17,18 @@ public class PayoneBankTransferCreateTransactionMethodProviderTest
 
     @Before
     public void setUp() throws Exception {
-        applyStubbing();
+        applyCustomFieldStubbing();
         transactionMethod = PayoneBankTransferCreateTransactionMethodProvider.of();
+    }
+
+    @Test
+    public void whenCreateTransactionFunctionApplied_addTransactionWithExpectedValuesIsCalled() {
+        PaymentMethodInfo paymentInterface = PaymentMethodInfoBuilder.of()
+                .paymentInterface("mockPaymentInterface")
+                .method(BANK_TRANSFER_ADVANCE).build();
+        applyPaymentStubbing(paymentInterface, Money.of(12.34, "EUR"));
+
+        super.whenCreateTransactionFunctionApplied_addTransactionWithExpectedValuesIsCalled(AUTHORIZATION, Money.of(12.34, "EUR"));
     }
 
     @Test

--- a/payone-adapter/src/test/java/com/commercetools/payment/payone/methods/transaction/PayoneCreditCardCreatePaymentTransactionMethodProviderTest.java
+++ b/payone-adapter/src/test/java/com/commercetools/payment/payone/methods/transaction/PayoneCreditCardCreatePaymentTransactionMethodProviderTest.java
@@ -1,9 +1,15 @@
 package com.commercetools.payment.payone.methods.transaction;
 
+import io.sphere.sdk.payments.PaymentMethodInfo;
+import io.sphere.sdk.payments.PaymentMethodInfoBuilder;
+import org.javamoney.moneta.Money;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
+
+import static com.commercetools.payment.payone.config.PayonePaymentMethodKeys.CREDIT_CARD;
+import static io.sphere.sdk.payments.TransactionType.CHARGE;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PayoneCreditCardCreatePaymentTransactionMethodProviderTest
@@ -11,8 +17,18 @@ public class PayoneCreditCardCreatePaymentTransactionMethodProviderTest
 
     @Before
     public void setUp() throws Exception {
-        applyStubbing();
+        applyCustomFieldStubbing();
         transactionMethod = PayoneCreditCardCreatePaymentTransactionMethodProvider.of();
+    }
+
+    @Test
+    public void whenCreateTransactionFunctionApplied_addTransactionWithExpectedValuesIsCalled() {
+        PaymentMethodInfo paymentInterface = PaymentMethodInfoBuilder.of()
+                .paymentInterface("mockPaymentInterface")
+                .method(CREDIT_CARD).build();
+        applyPaymentStubbing(paymentInterface, Money.of(67.99, "UAH"));
+
+        super.whenCreateTransactionFunctionApplied_addTransactionWithExpectedValuesIsCalled(CHARGE, Money.of(67.99, "UAH"));
     }
 
     @Test

--- a/payone-adapter/src/test/java/com/commercetools/payment/payone/methods/transaction/PayoneKlarnaCreatePaymentTransactionMethodProviderTest.java
+++ b/payone-adapter/src/test/java/com/commercetools/payment/payone/methods/transaction/PayoneKlarnaCreatePaymentTransactionMethodProviderTest.java
@@ -1,9 +1,15 @@
 package com.commercetools.payment.payone.methods.transaction;
 
+import io.sphere.sdk.payments.PaymentMethodInfo;
+import io.sphere.sdk.payments.PaymentMethodInfoBuilder;
+import org.javamoney.moneta.Money;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
+
+import static com.commercetools.payment.payone.config.PayonePaymentMethodKeys.INVOICE_KLARNA;
+import static io.sphere.sdk.payments.TransactionType.CHARGE;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PayoneKlarnaCreatePaymentTransactionMethodProviderTest
@@ -12,6 +18,17 @@ public class PayoneKlarnaCreatePaymentTransactionMethodProviderTest
     @Before
     public void setUp() throws Exception {
         transactionMethod = PayoneKlarnaCreatePaymentTransactionMethodProvider.of();
+    }
+
+    @Test
+    public void whenCreateTransactionFunctionApplied_addTransactionWithExpectedValuesIsCalled() {
+        PaymentMethodInfo paymentInterface = PaymentMethodInfoBuilder.of()
+                .paymentInterface("mockPaymentInterface")
+                .method(INVOICE_KLARNA)
+                .build();
+        applyPaymentStubbing(paymentInterface, Money.of(666.66, "INR"));
+
+        super.whenCreateTransactionFunctionApplied_addTransactionWithExpectedValuesIsCalled(CHARGE, Money.of(666.66, "INR"));
     }
 
     @Test

--- a/payone-adapter/src/test/java/com/commercetools/payment/payone/methods/transaction/PayonePaypalCreatePaymentTransactionMethodProviderTest.java
+++ b/payone-adapter/src/test/java/com/commercetools/payment/payone/methods/transaction/PayonePaypalCreatePaymentTransactionMethodProviderTest.java
@@ -1,9 +1,15 @@
 package com.commercetools.payment.payone.methods.transaction;
 
+import io.sphere.sdk.payments.PaymentMethodInfo;
+import io.sphere.sdk.payments.PaymentMethodInfoBuilder;
+import org.javamoney.moneta.Money;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
+
+import static com.commercetools.payment.payone.config.PayonePaymentMethodKeys.WALLET_PAYPAL;
+import static io.sphere.sdk.payments.TransactionType.CHARGE;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PayonePaypalCreatePaymentTransactionMethodProviderTest
@@ -11,8 +17,18 @@ public class PayonePaypalCreatePaymentTransactionMethodProviderTest
 
     @Before
     public void setUp() throws Exception {
-        applyStubbing();
+        applyCustomFieldStubbing();
         transactionMethod = PayonePaypalCreatePaymentTransactionMethodProvider.of();
+    }
+
+    @Test
+    public void whenCreateTransactionFunctionApplied_addTransactionWithExpectedValuesIsCalled() {
+        PaymentMethodInfo paymentInterface = PaymentMethodInfoBuilder.of()
+                .paymentInterface("mockPaymentInterface")
+                .method(WALLET_PAYPAL).build();
+        applyPaymentStubbing(paymentInterface, Money.of(11.22, "ZWD"));
+
+        super.whenCreateTransactionFunctionApplied_addTransactionWithExpectedValuesIsCalled(CHARGE, Money.of(11.22, "ZWD"));
     }
 
     @Test

--- a/src/it/com/commercetools/payment/BasePayoneTest.java
+++ b/src/it/com/commercetools/payment/BasePayoneTest.java
@@ -8,6 +8,7 @@ import io.sphere.sdk.carts.Cart;
 import io.sphere.sdk.client.BlockingSphereClient;
 import io.sphere.sdk.payments.Payment;
 import io.sphere.sdk.payments.Transaction;
+import io.sphere.sdk.payments.TransactionState;
 import io.sphere.sdk.payments.TransactionType;
 import io.sphere.sdk.types.CustomFields;
 import io.sphere.sdk.utils.MoneyImpl;
@@ -21,6 +22,7 @@ import java.util.concurrent.ExecutionException;
 
 import static com.commercetools.payment.payone.config.PayoneConfigurationNames.REFERENCE;
 import static com.commercetools.util.IntegrationTestUtils.*;
+import static io.sphere.sdk.payments.TransactionState.INITIAL;
 import static java.util.Optional.ofNullable;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -76,11 +78,12 @@ public class BasePayoneTest {
     /**
      * Assert default transaction creation results (operation result, Related Payment Objects)
      *
-     * @param ptcr {@link PaymentTransactionCreationResult} to validate.
+     * @param ptcr         {@link PaymentTransactionCreationResult} to validate.
      * @param expectedType expected transaction type from {@code payone.json} project settings.
      */
     protected void assertPaymentTransactionObjectCreation(PaymentTransactionCreationResult ptcr,
-                                                          TransactionType expectedType) {
+                                                          TransactionType expectedType,
+                                                          TransactionState expectedState) {
         assertThat(ptcr).isNotNull();
 
         assertThat(ptcr.getOperationResult())
@@ -93,7 +96,13 @@ public class BasePayoneTest {
         List<Transaction> transactions = payment.getTransactions();
         final int size = transactions.size();
         assertThat(size).isGreaterThan(0); // at least one has to be there
-        assertThat(transactions.get(size - 1).getType()).isEqualTo(expectedType);
+        Transaction transaction = transactions.get(size - 1);
+        assertThat(transaction.getType()).isEqualTo(expectedType);
+
+        // PaymentAdapterService.createPaymentTransaction() creates transaction and immediately handles the payment,
+        // and the payment handling - the status switches from INITIAL to some other
+        assertThat(transaction.getState()).isNotEqualByComparingTo(INITIAL);
+        assertThat(transaction.getState()).isEqualTo(expectedState);
     }
 
     /**

--- a/src/it/com/commercetools/payment/BasePayoneTest.java
+++ b/src/it/com/commercetools/payment/BasePayoneTest.java
@@ -100,7 +100,7 @@ public class BasePayoneTest {
         assertThat(transaction.getType()).isEqualTo(expectedType);
 
         // PaymentAdapterService.createPaymentTransaction() creates transaction and immediately handles the payment,
-        // and the payment handling - the status switches from INITIAL to some other
+        // thus after execution the status switches from INITIAL to some other
         assertThat(transaction.getState()).isNotEqualByComparingTo(INITIAL);
         assertThat(transaction.getState()).isEqualTo(expectedState);
     }

--- a/src/it/com/commercetools/payment/PayoneCreditCardTest.java
+++ b/src/it/com/commercetools/payment/PayoneCreditCardTest.java
@@ -14,6 +14,7 @@ import java.util.concurrent.ExecutionException;
 import static com.commercetools.config.ItConfig.getPayoneIntegrationUrl;
 import static com.commercetools.payment.payone.config.PayoneConfigurationNames.*;
 import static com.commercetools.payment.payone.config.PayonePaymentMethodKeys.CREDIT_CARD;
+import static io.sphere.sdk.payments.TransactionState.FAILURE;
 import static io.sphere.sdk.payments.TransactionType.AUTHORIZATION;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -59,7 +60,8 @@ public class PayoneCreditCardTest extends BasePayoneTest {
                                 .build())
                 .toCompletableFuture().get();
 
-        assertPaymentTransactionObjectCreation(paymentTransactionCreationResult, AUTHORIZATION);
+        // with random pseudocardpan (CREDIT_CARD_CARD_DATA_PLACEHOLDER) the payment should fail
+        assertPaymentTransactionObjectCreation(paymentTransactionCreationResult, AUTHORIZATION, FAILURE);
     }
 
     private void assertPaymentCreation(PaymentCreationResult paymentCreationResult, String reference) {

--- a/src/it/com/commercetools/payment/PayoneKlarnaTest.java
+++ b/src/it/com/commercetools/payment/PayoneKlarnaTest.java
@@ -6,7 +6,6 @@ import com.commercetools.payment.payone.config.PayonePaymentMethodKeys;
 import com.commercetools.payment.model.PaymentCreationResult;
 import com.commercetools.payment.model.PaymentTransactionCreationResult;
 import com.commercetools.payment.service.PaymentAdapterService;
-import io.sphere.sdk.payments.TransactionType;
 import io.sphere.sdk.types.CustomFields;
 import org.junit.After;
 import org.junit.Before;
@@ -17,6 +16,7 @@ import java.util.concurrent.ExecutionException;
 
 import static com.commercetools.config.ItConfig.getPayoneIntegrationUrl;
 import static com.commercetools.payment.payone.config.PayoneConfigurationNames.*;
+import static io.sphere.sdk.payments.TransactionState.FAILURE;
 import static io.sphere.sdk.payments.TransactionType.AUTHORIZATION;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -61,7 +61,8 @@ public class PayoneKlarnaTest extends BasePayoneTest {
                                 .build())
                 .toCompletableFuture().get();
 
-        assertPaymentTransactionObjectCreation(paymentTransactionCreationResult, AUTHORIZATION);
+        // with random data Klarna payment is expected to failure
+        assertPaymentTransactionObjectCreation(paymentTransactionCreationResult, AUTHORIZATION, FAILURE);
     }
 
     private void assertKlarnaPaymentCreation(PaymentCreationResult pcr, String reference) {

--- a/src/it/com/commercetools/payment/PayonePaypalTest.java
+++ b/src/it/com/commercetools/payment/PayonePaypalTest.java
@@ -5,7 +5,6 @@ import com.commercetools.payment.domain.CreatePaymentTransactionDataBuilder;
 import com.commercetools.payment.model.PaymentCreationResult;
 import com.commercetools.payment.model.PaymentTransactionCreationResult;
 import com.commercetools.payment.service.PaymentAdapterService;
-import io.sphere.sdk.payments.TransactionType;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -15,6 +14,7 @@ import java.util.concurrent.ExecutionException;
 import static com.commercetools.config.ItConfig.getPayoneIntegrationUrl;
 import static com.commercetools.payment.payone.config.PayonePaymentMethodKeys.WALLET_PAYPAL;
 import static com.commercetools.payment.payone.config.PayoneConfigurationNames.*;
+import static io.sphere.sdk.payments.TransactionState.PENDING;
 import static io.sphere.sdk.payments.TransactionType.CHARGE;
 
 /**
@@ -61,7 +61,7 @@ public class PayonePaypalTest extends BasePayoneTest {
                                 .build())
                 .toCompletableFuture().get();
 
-        assertPaymentTransactionObjectCreation(paymentTransactionCreationResult, CHARGE);
+        assertPaymentTransactionObjectCreation(paymentTransactionCreationResult, CHARGE, PENDING);
     }
 
 }

--- a/src/it/com/commercetools/payment/PayonePrepaidTest.java
+++ b/src/it/com/commercetools/payment/PayonePrepaidTest.java
@@ -5,7 +5,6 @@ import com.commercetools.payment.domain.CreatePaymentTransactionDataBuilder;
 import com.commercetools.payment.model.PaymentCreationResult;
 import com.commercetools.payment.model.PaymentTransactionCreationResult;
 import com.commercetools.payment.service.PaymentAdapterService;
-import io.sphere.sdk.payments.TransactionType;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -15,6 +14,7 @@ import java.util.concurrent.ExecutionException;
 import static com.commercetools.config.ItConfig.getPayoneIntegrationUrl;
 import static com.commercetools.payment.payone.config.PayonePaymentMethodKeys.BANK_TRANSFER_ADVANCE;
 import static com.commercetools.payment.payone.config.PayoneConfigurationNames.HANDLE_URL;
+import static io.sphere.sdk.payments.TransactionState.PENDING;
 import static io.sphere.sdk.payments.TransactionType.CHARGE;
 
 /**
@@ -59,7 +59,7 @@ public class PayonePrepaidTest extends BasePayoneTest {
                                 .build())
                 .toCompletableFuture().get();
 
-        assertPaymentTransactionObjectCreation(paymentTransactionCreationResult, CHARGE);
+        assertPaymentTransactionObjectCreation(paymentTransactionCreationResult, CHARGE, PENDING);
     }
 
 }

--- a/src/it/com/commercetools/payment/PayoneSofortTest.java
+++ b/src/it/com/commercetools/payment/PayoneSofortTest.java
@@ -12,8 +12,9 @@ import org.junit.Test;
 import java.util.concurrent.ExecutionException;
 
 import static com.commercetools.config.ItConfig.getPayoneIntegrationUrl;
-import static com.commercetools.payment.payone.config.PayonePaymentMethodKeys.BANK_TRANSFER_SOFORTUEBERWEISUNG;
 import static com.commercetools.payment.payone.config.PayoneConfigurationNames.*;
+import static com.commercetools.payment.payone.config.PayonePaymentMethodKeys.BANK_TRANSFER_SOFORTUEBERWEISUNG;
+import static io.sphere.sdk.payments.TransactionState.PENDING;
 import static io.sphere.sdk.payments.TransactionType.CHARGE;
 
 /**
@@ -58,7 +59,7 @@ public class PayoneSofortTest extends BasePayoneTest {
                                 .build())
                 .toCompletableFuture().get();
 
-        assertPaymentTransactionObjectCreation(paymentTransactionCreationResult, CHARGE);
+        assertPaymentTransactionObjectCreation(paymentTransactionCreationResult, CHARGE, PENDING);
     }
 
 }


### PR DESCRIPTION
Addresses issue #56 (Create transactions with explicitly set `Initial` state)

Related to previously released [Allow Initial to be processed same as Pending transaction state](https://github.com/commercetools/commercetools-payone-integration/releases/tag/v2.2.0)

Major change causes [only one line](https://github.com/commercetools/commercetools-payment-integration-java/pull/61/files#diff-575f1561ce1741a2735ee8f565fe496dR56)

The rest are the tests (including couple of previously missed cases)
